### PR TITLE
Prevent deletion of double selection of part

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -562,11 +562,11 @@ LRESULT CALLBACK KeyboardProc(int ncode, WPARAM wparam, LPARAM lparam) {
 					EditSelections(SimpleEdit(IsShiftPressed() ? SCI_LINEENDWRAPEXTEND : SCI_LINEENDWRAP));
 					return TRUE;
 				}
-				else if (wparam == VK_BACK) {
+				else if (wparam == VK_BACK && editor.GetSelectionEmpty()) {
 					EditSelections(SimpleEdit(SCI_DELETEBACK));
 					return TRUE;
 				}
-				else if (wparam == VK_DELETE) {
+				else if (wparam == VK_DELETE && editor.GetSelectionEmpty()) {
 					EditSelections(SimpleEdit(SCI_CLEAR));
 					return TRUE;
 				}


### PR DESCRIPTION
Only use deletion with multiple cursors, if no text is selected.
This fixes #20